### PR TITLE
Fixed :only_integer validation for integers larger than 32 bits

### DIFF
--- a/app/assets/javascripts/judge.js
+++ b/app/assets/javascripts/judge.js
@@ -62,7 +62,7 @@
 
   // Some nifty numerical helpers.
   var
-    isInt  = function(value) { return value === +value && value === (value|0); },
+    isInt  = function(value) { return Math.round(value) == value; },
     isEven = function(value) { return (value % 2 === 0) ? true : false; },
     isOdd  = function(value) { return !isEven(value); };
 


### PR DESCRIPTION
In my app users have to enter an eleven-digit integer registration code. The judge client-side validations always failed, however, since integers larger than 32 bits were not considered to be integers by the isInt function in judge.js. 
This pull request fixes that problem.
