### PR TITLE
Tweaks to work with AuthLogic and namespaced classes

### DIFF
--- a/app/assets/javascripts/judge.js
+++ b/app/assets/javascripts/judge.js
@@ -119,36 +119,40 @@
   };
 
   // Some helper methods for working with Rails-style input attributes.
-  var
-    attrFromName = function(name) {
-      var matches, attr = '';
-      if (matches = name.match(/\[(\w+)\]$/)) {
-        attr = matches[1];
-      }
-      return attr;
-    };
-    classFromName = function(name) {
-      var bracketed, klass = '';
-      if (bracketed = name.match(/\[(\w+)\]/g)) {
-        klass = (bracketed.length > 1) ? camelize(debracket(bracketed[0])) : name.match(/^\w+/)[0];
-      }
-      return klass;
-    };
-    debracket = function(str) {
-      return str.replace(/\[|\]/g, '');
-    };
-    camelize = function(str) {
-      return str.replace(/(^[a-z]|\_[a-z])/g, function($1) {
-        return $1.toUpperCase().replace('_','');
-      });
-    };
+  var attrFromName = function(name) {
+    var matches, attr = '';
+    if (matches = name.match(/\[(\w+)\]$/)) {
+      attr = matches[1];
+    }
+    return attr;
+  };
+  var classFromName = function(name) {
+    var bracketed, klass = '';
+    if (bracketed = name.match(/\[(\w+)\]/g)) {
+      klass = (bracketed.length > 1) ? camelize(debracket(bracketed[0])) : name.match(/^\w+/)[0];
+    }
+    return klass;
+  };
+  var debracket = function(str) {
+    return str.replace(/\[|\]/g, '');
+  };
+  var camelize = function(str) {
+    return str.replace(/(^[a-z]|\_[a-z])/g, function($1) {
+      return $1.toUpperCase().replace('_','');
+    });
+  };
+  // Allow for overriding the class name to be sent to judge to allow for namespace modules
+  var classFromEl = function(el) {
+    var klass = el.getAttribute('data-model-class');
+    return klass || classFromName(el.name);
+  }
 
   // Build the URL necessary to send a GET request to the mounted validations
   // controller to check the validity of the given form element.
   var urlFor = judge.urlFor = function(el, kind) {
     var path   = judge.enginePath,
         params = {
-          'klass'    : classFromName(el.name),
+          'klass'    : classFromEl(el),
           'attribute': attrFromName(el.name),
           'value'    : el.value,
           'kind'     : kind

--- a/app/assets/javascripts/judge.js
+++ b/app/assets/javascripts/judge.js
@@ -75,10 +75,16 @@
     var on = string.split('-')[0];
     return (/m/.test(on)) ? 'm' : '';
   };
+  var convertSource = function(string) {
+    var newSource = string.replace(/\\\\/g, '\\')
+    newSource = newSource.replace('\\\A', '^');
+    newSource = newSource.replace('\\\z', '$');
+    return newSource;
+  };
   var convertRegExp = function(string) {
     var parts  = string.slice(1, -1).split(':'),
         flags  = parts.shift().replace('?', ''),
-        source = parts.join(':').replace(/\\\\/g, '\\');
+        source = convertSource(parts.join(':'));
     return new RegExp(source, convertFlags(flags));
   };
 

--- a/app/assets/javascripts/judge.js
+++ b/app/assets/javascripts/judge.js
@@ -72,8 +72,7 @@
   // with an XRegExp plugin which will port some Ruby regexp features to
   // JavaScript.
   var convertFlags = function(string) {
-    var on = string.split('-')[0];
-    return (/m/.test(on)) ? 'm' : '';
+    return string.replace(/[^im]/g, '');
   };
   var convertSource = function(string) {
     var newSource = string.replace(/\\\\/g, '\\')

--- a/spec/javascripts/judge-spec.js
+++ b/spec/javascripts/judge-spec.js
@@ -450,6 +450,23 @@ describe('judge', function() {
           expect(validation).toBeInvalidWith(['Request error: 500']);
         });
       });
+      describe('specified class name', function() {
+        beforeEach(function() {
+          el.setAttribute('data-model-class', 'MyModule::Leader');
+        });
+        it('makes request using specified class name if it is present', function() {
+            runs(function() {
+            server.respondWith([200, {}, '[]']);
+            validation = validator({}, {});
+          });
+          runs(function() {
+            server.respond();
+          });
+          runs(function() {
+            expect(server.requests[0].url).toBe('/judge?klass=MyModule%3A%3ALeader&attribute=email&value=leader%40team.com&kind=uniqueness');
+          });
+        });
+      });
     });
 
     describe('user added validator', function() {


### PR DESCRIPTION
Authlogic uses regular expression validations containing \A and \z (e.g. for email and username validation) added replacement to ^ and $ so that it works on the client side. 

Using form_for with a class inside a module meant my input fields had names like module_class_name. The   logic to get the module name does not cope well with this, so I added an optional data attribute data-model-name to the input element. If this is present, it's used for uniqueness validations. 