### PR TITLE
remove status check from tryClose

### DIFF
--- a/app/assets/javascripts/judge.js
+++ b/app/assets/javascripts/judge.js
@@ -222,9 +222,7 @@
         this.trigger('close', this.element, status, report.messages);
 
         // handle named callbacks
-        if (status === eventName) {
-          this.trigger(status, this.element, report.messages);
-        }
+        this.trigger(status, this.element, report.messages);
       }
     }
   });

--- a/app/assets/javascripts/judge.js
+++ b/app/assets/javascripts/judge.js
@@ -390,8 +390,8 @@
     if (_.isFunction(callbacks)) {
       queue.on('close', callbacks);
     } else if (isCallbacksObj(callbacks)) {
-      queue.on('valid', callbacks.valid);
-      queue.on('invalid', callbacks.invalid);
+      queue.on('valid', _.once(callbacks.valid));
+      queue.on('invalid', _.once(callbacks.invalid));
     }
     return queue;
   };


### PR DESCRIPTION
I think this may be the cause for this issue:
https://github.com/joecorcoran/judge/issues/42

The check on line 225 fails when the last validation to initiate the tryClose callback has a different status than the rest of the validations.

This prevents the valid/invalid callbacks from running on this field.