### PR TITLE
pass object class name with a data attribute instead of parsing the input's name

### DIFF
--- a/app/assets/javascripts/judge.js
+++ b/app/assets/javascripts/judge.js
@@ -121,14 +121,6 @@
       }
       return attr;
     };
-    debracket = function(str) {
-      return str.replace(/\[|\]/g, '');
-    };
-    camelize = function(str) {
-      return str.replace(/(^[a-z]|\_[a-z])/g, function($1) {
-        return $1.toUpperCase().replace('_','');
-      });
-    };
     originalValue = function(el) {
       var validations = JSON.parse(el.getAttribute('data-validate'));
       var validation = _.filter(validations, function (validation) { return validation.kind === "uniqueness"})[0];

--- a/app/assets/javascripts/judge.js
+++ b/app/assets/javascripts/judge.js
@@ -121,13 +121,6 @@
       }
       return attr;
     };
-    classFromName = function(name) {
-      var bracketed, klass = '';
-      if (bracketed = name.match(/\[(\w+)\]/g)) {
-        klass = (bracketed.length > 1) ? camelize(debracket(bracketed[0])) : name.match(/^\w+/)[0];
-      }
-      return klass;
-    };
     debracket = function(str) {
       return str.replace(/\[|\]/g, '');
     };
@@ -147,7 +140,7 @@
   var urlFor = judge.urlFor = function(el, kind) {
     var path   = judge.enginePath,
         params = {
-          'klass'    : classFromName(el.name),
+          'klass'    : el.getAttribute('data-klass'),
           'attribute': attrFromName(el.name),
           'value'    : el.value,
           'kind'     : kind

--- a/lib/judge/html.rb
+++ b/lib/judge/html.rb
@@ -1,10 +1,11 @@
 module Judge
   module Html
     extend self
-    
+
     def attrs_for(object, method)
       {
-        "data-validate" => ValidatorCollection.new(object, method).to_json
+        'data-validate' => ValidatorCollection.new(object, method).to_json,
+        'data-klass'    => object.class.name
       }
     end
   end

--- a/spec/javascripts/judge-spec.js
+++ b/spec/javascripts/judge-spec.js
@@ -446,7 +446,8 @@ describe('judge', function() {
         validator  = _.bind(judge.eachValidators.uniqueness, el);
         el.value   = 'leader@team.com';
         el.name    = 'team[leader][email]';
-        el.setAttribute('data-validate', uniquenessAttr)
+        el.setAttribute('data-validate', uniquenessAttr);
+        el.setAttribute('data-klass', 'Leader');
       });
       it('returns a pending Validation', function() {
         validation = validator({}, {});


### PR DESCRIPTION
This fixes an issue I've run into with nested models, specifically from an engine. Passing an`Engine::User`instance through to simple_form or form_for will only create input names from the base class by default. This leave Judge trying to match `Engine::User` with `User` and returning a `NullValidation`.

My solution is to pass the class name directly through as a data attribute. Tests are passing and it works like a charm for nested and unested models. Let me know what you think.

thanks