### PR TITLE
Fix uniqueness validation after source code changes (take 2)

### DIFF
--- a/lib/judge/config.rb
+++ b/lib/judge/config.rb
@@ -13,7 +13,7 @@ module Judge
     end
 
     def exposed
-      @@exposed.map { |k, v| [k.constantize, v] }.to_h
+      @@exposed
     end
 
     def exposed?(klass, attribute)

--- a/lib/judge/config.rb
+++ b/lib/judge/config.rb
@@ -8,7 +8,7 @@ module Judge
     @@ignore_unsupported_validators = false
 
     def expose(klass, *attributes)
-      attrs = (@@exposed[klass] ||= [])
+      attrs = (@@exposed[klass.name] ||= [])
       attrs.concat(attributes).uniq!
     end
 
@@ -17,15 +17,15 @@ module Judge
     end
 
     def exposed?(klass, attribute)
-      @@exposed.has_key?(klass) && @@exposed[klass].include?(attribute)
+      @@exposed.has_key?(klass.name) && @@exposed[klass.name].include?(attribute)
     end
 
     def unexpose(klass, *attributes)
       attributes.each do |a|
-        @@exposed[klass].delete(a)
+        @@exposed[klass.name].delete(a)
       end
-      if attributes.empty? || @@exposed[klass].empty?
-        @@exposed.delete(klass)
+      if attributes.empty? || @@exposed[klass.name].empty?
+        @@exposed.delete(klass.name)
       end
     end
     

--- a/lib/judge/config.rb
+++ b/lib/judge/config.rb
@@ -13,7 +13,7 @@ module Judge
     end
 
     def exposed
-      @@exposed
+      @@exposed.map { |k, v| [k.constantize, v] }.to_h
     end
 
     def exposed?(klass, attribute)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -19,7 +19,7 @@ describe Judge::Config do
         Judge.configure do
           expose User, :username, :email
         end
-        Judge.config.exposed[User].should eql [:username, :email]
+        Judge.config.exposed['User'].should eql [:username, :email]
       end
 
       it "accepts multiple declarations for the same class" do
@@ -27,7 +27,7 @@ describe Judge::Config do
           expose User, :username
           expose User, :username, :email
         end
-        Judge.config.exposed[User].length.should eq 2
+        Judge.config.exposed['User'].length.should eq 2
       end
     end
     describe "unexpose" do
@@ -40,7 +40,7 @@ describe Judge::Config do
         Judge.configure do
           unexpose User, :email
         end
-        Judge.config.exposed[User].length.should eq 1
+        Judge.config.exposed['User'].length.should eq 1
       end
       it "removes whole class when no attributes given" do
         Judge.configure do


### PR DESCRIPTION
Re-opening @hgani's PR #78, with passing tests (hopefully).

> There has been a suggested workaround, but the workaround doesn't work for me.
>
> This pull request aims to fix this problem properly so no workaround is needed.
>
> Basically what it does is use class name as the key for expose instead of using the class itself, which will break when Rails autoloads the class, because then the existing key/class will not match with the reloaded class.