### PR TITLE
release v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+* **3.0.0**
+    - Updates Rails support to 5.0+ and Ruby support to 2.2+
+    - [#71](https://github.com/joecorcoran/judge/pull/71): Add Code of Conduct from contributor-covenant.org
+    - [#72](https://github.com/joecorcoran/judge/pull/72): Add `telephone_field` support
+    - [#75](https://github.com/joecorcoran/judge/pull/75): Additional documentation for error messages
+    - [#78](https://github.com/joecorcoran/judge/pull/78): Fix uniqueness validation after source code changes
+    - [#83](https://github.com/joecorcoran/judge/pull/83): Remove `ActiveModel::Errors#get` deprecation for Rails 5.1
 * **2.1.1**
     - [#63](https://github.com/joecorcoran/judge/pull/63): add array length validation
     - [#68](https://github.com/joecorcoran/judge/pull/68): count newlines as two characters when validating length

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ In many cases it would be simpler to safely expose the validation information fr
 
 ## Installation
 
-Judge supports Rails >= 5.0.  
-If you require Rails 4 support, please use Judge ~> 2.1.0.
+Judge supports Rails 5.0+.
+If you require Rails 4 support, please use version 2.1.x.
 
 Judge relies on [Underscore.js](underscore) in general and [JSON2.js](json2) for browsers that lack proper JSON support. If your application already makes use of these files, you can safely ignore the versions provided with Judge.
 

--- a/lib/judge/version.rb
+++ b/lib/judge/version.rb
@@ -1,3 +1,3 @@
 module Judge
-  VERSION = '2.1.1'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
Updating to major version as changes include deprecating Rails 4 and older Ruby versions. I'll tag and release gem after merged. Fixes #87.

@joecorcoran Any concerns?